### PR TITLE
PKCS11 HSM integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ INCLUDES = 	-Itools/header_generation/create_hdr_isbc/include/ \
 		-Itaal/include -Icommon/include \
 		-I$(LIB_HASH_DRBG_INCLUDE_PATH)
 
-CCFLAGS= -g -Wall -Wno-strict-aliasing -Werror $(INCLUDES)
+CCFLAGS= -g -Wall -Wno-strict-aliasing -Werror $(INCLUDES) -Wno-deprecated-declarations
 
 INSTALL_BINARIES = 	create_hdr_isbc create_hdr_esbc \
 			create_hdr_pbi create_hdr_cf \

--- a/common/parse_utils.c
+++ b/common/parse_utils.c
@@ -283,10 +283,11 @@ int cal_line_size(FILE *fp)
 void get_field_from_file(char *line, char *field_name)
 {
 	int i = 0;
-	char delims[] = ",;=";
+	char fdelims[] = "=;,";
+	char delims[] = ",";
 	char *result = NULL;
 
-	result = strtok(line, delims);
+	result = strtok(line, fdelims);
 	while (result != NULL) {
 		result = strtok(NULL, delims);
 		file_field.value[i] = result;

--- a/scripts/uni_sign
+++ b/scripts/uni_sign
@@ -1,5 +1,25 @@
 #!/bin/bash
 
+OPENSSL_CNF=$(cat <<EOF
+.include /usr/lib/ssl/openssl.cnf
+.include openssl_engine_include.cnf
+EOF
+)
+
+OPENSSL_ENGINE_INCLUDE_CNF=$(cat <<EOF
+[openssl_init]
+engines = engine_section
+
+[engine_section]
+pkcs = pkcs11_section
+
+[pkcs11_section]
+engine_id = pkcs11
+MODULE_PATH = /usr/lib/x86_64-linux-gnu/libykcs11.so
+init = 1
+EOF
+)
+
 #-----------------------------------------------------------------------------
 #
 # File: uni_sign
@@ -54,6 +74,11 @@ print_help() {
 ############################################################
 # Script Starts Here
 ############################################################
+echo "${OPENSSL_CNF}" > /tmp/openssl.cnf
+echo "${OPENSSL_ENGINE_INCLUDE_CNF}" > /tmp//openssl_engine_include.cnf
+export OPENSSL_CONF=/tmp/openssl.cnf
+export OPENSSL_CONF_INCLUDE=/tmp
+
 echo ""
 
 # Check if proper arguments are specified

--- a/tools/header_generation/create_hdr_common.c
+++ b/tools/header_generation/create_hdr_common.c
@@ -39,7 +39,7 @@
 #include <crypto_utils.h>
 
 extern struct g_data_t gd;
-struct input_field file_field;
+extern struct input_field file_field;
 
 extern char line_data[];
 static struct option long_options[] = {

--- a/tools/pbi_creation/create_pbi_common.c
+++ b/tools/pbi_creation/create_pbi_common.c
@@ -57,7 +57,7 @@ static char *parse_list[] = {
 
 extern struct g_data_t gd;
 extern char line_data[];
-struct input_field file_field;
+extern struct input_field file_field;
 
 #define NUM_PARSE_LIST (sizeof(parse_list) / sizeof(char *))
 


### PR DESCRIPTION
To use this, key names are derived from the
PKCS11 URI format. So instead of local files,
use the URI.
The spliced openssl configuration include
then temporarily extends openssl with a
pkcs11 extension for your HSM.