### PR TITLE
Replaced low-level RSA funcs with EVP iface and added gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+platforms
+*.a
+*.o
+create_hdr_cf
+create_hdr_esbc
+create_hdr_isbc
+create_hdr_pbi
+gen_drv_drbg
+gen_fusescr
+gen_keys
+gen_otpmk_drbg
+gen_sign
+sign_embed
+uni_cfsign
+uni_pbi
+uni_sign

--- a/tools/header_generation/create_hdr_common.c
+++ b/tools/header_generation/create_hdr_common.c
@@ -39,7 +39,7 @@
 #include <crypto_utils.h>
 
 extern struct g_data_t gd;
-struct input_field file_field;
+extern struct input_field file_field;
 
 extern char line_data[];
 static struct option long_options[] = {

--- a/tools/pbi_creation/create_pbi_common.c
+++ b/tools/pbi_creation/create_pbi_common.c
@@ -57,7 +57,7 @@ static char *parse_list[] = {
 
 extern struct g_data_t gd;
 extern char line_data[];
-struct input_field file_field;
+extern struct input_field file_field;
 
 #define NUM_PARSE_LIST (sizeof(parse_list) / sizeof(char *))
 


### PR DESCRIPTION
Addresses https://github.com/nxp-qoriq/cst/issues/3 by updating OpenSSL calls. No longer requires passing `-Wno-deprecated-declarations` to build.