### PR TITLE
common: Initialize ret in create_srk_clac_hash to allow compile with '-Og'

### DIFF
--- a/tools/header_generation/create_hdr_common.c
+++ b/tools/header_generation/create_hdr_common.c
@@ -394,7 +394,7 @@ int create_hdr(int argc, char **argv)
  ***************************************************************************/
 int create_srk_calc_hash(uint32_t max_keys)
 {
-	int i, ret;
+	int i, ret = SUCCESS;
 	uint32_t key_len;
 	uint8_t ctx[CRYPTO_HASH_CTX_SIZE];
 


### PR DESCRIPTION
Fix following error if compile with '-Og':

tools/header_generation/create_hdr_common.c: In function ‘create_srk_calc_hash’: tools/header_generation/create_hdr_common.c:460:16: error: ‘ret’ may be used uninitialized [-Werror=maybe-uninitialized]
  460 |         return ret;
      |                ^~~
tools/header_generation/create_hdr_common.c:397:16: note: ‘ret’ was declared here
  397 |         int i, ret;
      |                ^~~

Tested on Debian trixie with GCC-12.4 and GCC-14.2.

We use this in Yocto-base GyroidOS to build ASAN images for debugging which globally enables the '-Og' flag on all repositories.